### PR TITLE
v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.2.0 (Jul 2, 2020)
+
+ * feat(config): Added `graceful` flag to `load()` that won't throw an error if the file does not
+   exist.
+
 # v1.1.0 (Jun 30, 2020)
 
  * fix(config): Fixed bug when loading a layer that already exists with a file that was causing the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "config-kit",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A universal, layered configuration system.",
   "main": "./dist/index.js",
   "author": "Axway, Inc. <npmjs@appcelerator.com>",


### PR DESCRIPTION
feat(config): Added 'graceful' flag to 'load()' that won't throw an error if the file does not exist.

There are times where we want to try to load the config, and sometimes into more than one layer, and we don't want to error out if the load fails.