### PR TITLE
Watch delete fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.2.1 (Jul 3, 2020)
+
+ * fix(config): Fixed duplicate watch events when deleting across multiple layers.
+ * fix(node): Node hash was not being properly calculated when a property was deleted.
+ * style: Added debug logging to the config mutation functions: `delete()`, `set()`, `push()`,
+   `pop()`, `shift()`, and `unshift()`.
+
 # v1.2.0 (Jul 2, 2020)
 
  * feat(config): Added `graceful` flag to `load()` that won't throw an error if the file does not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "config-kit",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A universal, layered configuration system.",
   "main": "./dist/index.js",
   "author": "Axway, Inc. <npmjs@appcelerator.com>",

--- a/src/node.js
+++ b/src/node.js
@@ -214,7 +214,7 @@ export default class Node {
 					result = delete target[prop];
 
 					delete internal.hashes[prop];
-					internal.hash = hashValue(Object.values(internal.hashes));
+					internal.hash = hashValue(internal.hashes);
 
 					if (result) {
 						internal.notify(node);


### PR DESCRIPTION
fix(config): Fixed duplicate watch events when deleting across multiple layers.
fix(node): Node hash was not being properly calculated when a property was deleted.
style: Added debug logging to the config mutation functions: delete(), set(), push(), pop(), shift(), and unshift().