### PR TITLE
Namespace refactor, minor bug fixes, fixed tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# v1.3.0
+
+ * fix(Layer): Move layer namespace handling from store to layer.
+ * fix(Layer): Allow `has()` to be passed an empty key.
+ * fix(Layer): Added schema validation when initializing a layer with data.
+ * fix(LayerList): Moved `Base` layer definition from `Config` into `LayerList` because the layer
+   schema validator needs the base layer's schema and we need to make sure the base layer exists
+   and thus needs to own the `Base` symbol.
+ * fix(LayerList): Validator should only use base layer's schema and current layer's schema to
+   validate, not all layer's schemas.
+ * fix(LayerList): Fixed bug where layers were not being inserted into the layer list sequentially.
+ * fix(JSONStore): Fixed `get()` and `has()` to only iterate over the data object if the `key` has
+   a length.
+ * fix(util): In `getSchemaInitialValues()`, only return `env` object if there were environment
+   variable values found.
+ * refactor(Store): Changed `Store.load()` to only take a `file`. Not counting this as a breaking
+   change as it's an internal API.
+ * build: Update Babel config from Node 8 to Node 10.
+ * test: Added several namespace related tests.
+ * test: Fixed several bad tests.
+ * chore: Migrated from `@hapi/joi` to `joi`.
+
 # v1.2.1 (Jul 3, 2020)
 
  * fix(config): Fixed duplicate watch events when deleting across multiple layers.

--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ in this distribution for more information.
 [david-url]: https://david-dm.org/appcelerator/config-kit
 [david-dev-image]: https://img.shields.io/david/dev/appcelerator/config-kit.svg
 [david-dev-url]: https://david-dm.org/appcelerator/config-kit#info=devDependencies
-[joi]: https://www.npmjs.com/package/@hapi/joi
+[joi]: https://www.npmjs.com/package/joi

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,5 +4,5 @@ require('appcd-gulp')({
 	exports,
 	pkgJson:  require('./package.json'),
 	template: 'standard',
-	babel:    'node8'
+	babel:    'node10'
 });

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "@hapi/joi": "^17.1.1",
     "fs-extra": "^9.0.1",
     "import-fresh": "^3.2.1",
+    "joi": "^17.3.0",
     "snooplogg": "^3.0.0",
     "source-map-support": "^0.5.19"
   },

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,7 @@
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 import JSStore from './stores/js-store';
 import JSONStore from './stores/json-store';
-import LayerList, { All } from './layer-list';
+import LayerList, { All, Base } from './layer-list';
 import Node from './node';
 import path from 'path';
 import snooplogg from 'snooplogg';
@@ -30,7 +30,7 @@ export default class Config {
 	 * @type {Symbol}
 	 * @access public
 	 */
-	static Base = Symbol('base');
+	static Base = Base;
 
 	/**
 	 * A reference to the Joi schema library.
@@ -83,7 +83,7 @@ export default class Config {
 	 * @param {String} [opts.file] - The file to associate with the base layer.
 	 * @param {Object|Layer|Array.<Object|Layer>} [opts.layers] - One or more layers to add in
 	 * addition to the base layer.
-	 * @param {Object} [opts.schema] - A Joi schema or object to compile into a Joi schema.
+	 * @param {Object} [opts.schema] - A Joi schema for the base layer.
 	 * @param {Store|Function} [opts.store] - A store instance or store class to use for the base
 	 * layer.
 	 * @param {Function|Array.<Function>} [opts.stores] - A store class or array of store classes
@@ -123,18 +123,11 @@ export default class Config {
 
 		this.layers = new LayerList({
 			allowNulls:   opts.allowNulls,
-			allowUnknown: opts.allowUnknown
-		});
-
-		this.layers.add({
-			data:     opts.data,
-			file:     opts.file,
-			id:       Config.Base,
-			order:    -Infinity,
-			readonly: false,
-			schema:   opts.schema,
-			static:   true,
-			store
+			allowUnknown: opts.allowUnknown !== false,
+			data:         opts.data,
+			file:         opts.file,
+			schema:       opts.schema,
+			store:        opts.store
 		});
 
 		for (const layer of arrayify(opts.layers)) {

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ if (!Error.prepareStackTrace) {
 }
 
 import Config from './config';
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 import JSStore from './stores/js-store';
 import JSONStore from './stores/json-store';
 import Layer from './layer';

--- a/src/layer-list.js
+++ b/src/layer-list.js
@@ -70,7 +70,7 @@ export default class LayerList {
 
 		this.layers.push(this.map[Base] = new Layer({
 			allowNulls: opts.allowNulls,
-			data:       opts.data || {},
+			data:       opts.data,
 			file:       opts.file,
 			id:         Base,
 			order:      -Infinity,

--- a/src/layer.js
+++ b/src/layer.js
@@ -1,11 +1,11 @@
 import fs from 'fs-extra';
 import importFresh from 'import-fresh';
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 import JSONStore from './stores/json-store';
 import path from 'path';
 import snooplogg from 'snooplogg';
 import Store from './store';
-import Values from '@hapi/joi/lib/values';
+import Values from 'joi/lib/values';
 import { getSchemaInitialValues, validate } from './util';
 
 const { log } = snooplogg('config-kit')('js-store');
@@ -137,8 +137,15 @@ export default class Layer {
 			this.store = new JSONStore(opts.store || { data: defaults, schema: this.schema });
 		}
 
-		if (opts.data) {
-			this.store.merge(opts.data);
+		let { data } = opts;
+		if (data) {
+			if (typeof data !== 'object') {
+				throw new TypeError('Expected layer data to be an object');
+			}
+
+			if (data && typeof data === 'object') {
+				this.merge(this.namespace ? { [this.namespace]: data } : data);
+			}
 		}
 
 		if (opts.file) {
@@ -146,6 +153,8 @@ export default class Layer {
 		}
 
 		if (env) {
+			// we can merge the environment variable values directly into the store since we've
+			// already done the validation in `getSchemaInitialValues()`
 			this.store.merge(env);
 		}
 	}
@@ -154,7 +163,7 @@ export default class Layer {
 	 * Sets a value for the specified key.
 	 *
 	 * @param {Array.<String>} key - The key to set.
-	 * @returns {Layer}
+	 * @returns {Boolean}
 	 */
 	delete(key) {
 		if (this.readonly) {
@@ -166,7 +175,11 @@ export default class Layer {
 		}
 
 		this.validate({ action: 'delete', key });
-		return this.store.delete(key);
+		if (key = this.resolveKey(key)) {
+			return this.store.delete(key);
+		}
+
+		return false;
 	}
 
 	/**
@@ -178,7 +191,19 @@ export default class Layer {
 	 * @access public
 	 */
 	get(key) {
-		return this.store && this.store.get(key);
+		const nsKey = this.resolveKey(key);
+		if (nsKey !== null) {
+			let value = this.store.get(nsKey);
+			if (!nsKey?.length && value === undefined) {
+				// set to empty object if value
+				value = {};
+			}
+			if (key.length && this.namespace && key[0] === this.namespace) {
+				// return a specific value
+				return value;
+			}
+			return this.namespace ? { [this.namespace]: value } : value;
+		}
 	}
 
 	/**
@@ -189,7 +214,14 @@ export default class Layer {
 	 * @access public
 	 */
 	has(key) {
-		return this.store.has(key);
+		const nsKey = this.resolveKey(key);
+		if (nsKey !== null) {
+			if (key.length === 1 && this.namespace && key[0] === this.namespace) {
+				return true;
+			}
+			return this.store.has(nsKey);
+		}
+		return false;
 	}
 
 	/**
@@ -214,10 +246,12 @@ export default class Layer {
 		}
 
 		if (!graceful || exists) {
-			this.store.load({
-				file,
-				ns: this.namespace,
-				validate: value => this.validate({ action: 'load', message: 'Failed to load config file', value })
+			this.store.load(file);
+			const data = this.store.get();
+			this.validate({
+				action: 'load',
+				message: 'Failed to load config file',
+				value: this.namespace ? { [this.namespace]: data } : data
 			});
 		}
 
@@ -320,7 +354,8 @@ export default class Layer {
 		this.schema = schema;
 
 		if (this.store) {
-			this.store.schema = schema;
+			// we force set the schema in the store
+			this.store.schema = this.namespace && schema.$_terms.keys?.find(s => s.key === this.namespace)?.schema || schema;
 		}
 
 		return this;
@@ -337,9 +372,26 @@ export default class Layer {
 		if (this.readonly) {
 			throw new Error(`Layer "${String(this.id)}" is readonly`);
 		}
-		this.validate({ value, action: 'merge' });
-		this.store.merge(value);
+		this.validate({ action: 'merge', value });
+		if ((!this.namespace || (value = value[this.namespace])) && typeof value === 'object') {
+			this.store.merge(value);
+		}
 		return this;
+	}
+
+	/**
+	 * Checks if this layer has a namespaces and if the key has the namespace, then returns the
+	 * resolved key.
+	 *
+	 * @param {Array.<String>} key - The key to resolve.
+	 * @returns {Array.<String>}
+	 * @access private
+	 */
+	resolveKey(key) {
+		if (key.length && this.namespace) {
+			return key[0] === this.namespace ? key.slice(1) : null;
+		}
+		return key;
 	}
 
 	/**
@@ -373,7 +425,10 @@ export default class Layer {
 		}
 
 		this.validate({ action, key, value });
-		this.store.set(key, value);
+		if (key = this.resolveKey(key)) {
+			this.store.set(key, value);
+		}
+
 		return this;
 	}
 
@@ -424,11 +479,10 @@ export default class Layer {
 	 * @type {Function}
 	 */
 	get validate() {
-		return args => {
-			return typeof this.validator === 'function'
-				? this.validator(args)
-				: validate({ schemas: [ this.schema ], ...args });
-		};
+		return args => (this.validator || validate)({
+			schemas: this.schema ? [ this.schema ] : [],
+			...args
+		});
 	}
 
 	set validate(fn) {

--- a/src/store.js
+++ b/src/store.js
@@ -61,13 +61,10 @@ export default class Store {
 	/**
 	 * Loads a config file.
 	 *
-	 * @param {Object} opts - Various options
-	 * @param {String} opts.file - The path to the config file to load.
-	 * @param {String} [opts.ns] - A namespace to wrap around the loaded data.
-	 * @param {Function} [opts.validate] - A function to validate the data against a schema.
+	 * @param {String} file - The path to the config file to load.
 	 * @access public
 	 */
-	load(opts) {
+	load(file) {
 		throw new Error('load() not implemented');
 	}
 

--- a/src/stores/js-store.js
+++ b/src/stores/js-store.js
@@ -20,14 +20,11 @@ export default class JSStore extends JSONStore {
 	/**
 	 * Loads a config file.
 	 *
-	 * @param {Object} opts - Various options
-	 * @param {String} opts.file - The path to the config file to load.
-	 * @param {String} [opts.ns] - A namespace to wrap around the loaded data.
-	 * @param {Function} [opts.validate] - A function to validate the data against a schema.
+	 * @param {String} file - The path to the config file to load.
 	 * @returns {JSONStore}
 	 * @access public
 	 */
-	load({ file, ns, validate }) {
+	load(file) {
 		if (!fs.existsSync(file)) {
 			const err = Error(`File not found: ${file}`);
 			err.code = 'ENOENT';
@@ -48,14 +45,6 @@ export default class JSStore extends JSONStore {
 
 		if (!data || typeof data !== 'object') {
 			throw new TypeError('Expected config file to be an object');
-		}
-
-		if (ns && !Object.prototype.hasOwnProperty.call(data, ns)) {
-			data = { [ns]: data };
-		}
-
-		if (typeof validate === 'function') {
-			validate(data);
 		}
 
 		this.data = new Node(data);

--- a/src/stores/json-store.js
+++ b/src/stores/json-store.js
@@ -88,7 +88,7 @@ export default class JSONStore extends Store {
 	get(key) {
 		let { data } = this;
 
-		if (key) {
+		if (key?.length) {
 			for (let i = 0, prop; data !== undefined && (prop = key[i++]); data = data[prop]) {
 				if (typeof data !== 'object') {
 					return;
@@ -111,7 +111,7 @@ export default class JSONStore extends Store {
 	has(key) {
 		let { data } = this;
 
-		if (key) {
+		if (key?.length) {
 			for (let i = 0, prop; data !== undefined && (prop = key[i++]); data = data[prop]) {
 				if (typeof data !== 'object') {
 					return false;
@@ -125,14 +125,11 @@ export default class JSONStore extends Store {
 	/**
 	 * Loads a config file.
 	 *
-	 * @param {Object} opts - Various options
-	 * @param {String} opts.file - The path to the config file to load.
-	 * @param {String} [opts.ns] - A namespace to wrap around the loaded data.
-	 * @param {Function} [opts.validate] - A function to validate the data against a schema.
+	 * @param {String} file - The path to the config file to load.
 	 * @returns {JSONStore}
 	 * @access public
 	 */
-	load({ file, ns, validate }) {
+	load(file) {
 		if (!fs.existsSync(file)) {
 			const err = new Error(`File not found: ${file}`);
 			err.code = 'ENOENT';
@@ -159,14 +156,6 @@ export default class JSONStore extends Store {
 
 		if (!data || typeof data !== 'object') {
 			throw new TypeError('Expected config file to be an object');
-		}
-
-		if (ns && !Object.prototype.hasOwnProperty.call(data, ns)) {
-			data = { [ns]: data };
-		}
-
-		if (typeof validate === 'function') {
-			data = validate(data);
 		}
 
 		Node.merge(this.data, data);

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,4 @@
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 import snooplogg from 'snooplogg';
 
 /**
@@ -71,7 +71,7 @@ export function getSchemaInitialValues(schema) {
 		}
 	}
 
-	return { defaults, env };
+	return { defaults, env: Object.keys(env).length ? env : null };
 }
 
 /**

--- a/test/test-json-store.js
+++ b/test/test-json-store.js
@@ -286,6 +286,20 @@ describe('JSONStore', () => {
 			expect(cfg.has('foo.pow')).to.equal(true);
 			expect(cfg.has('foo.pow.wiz')).to.equal(false);
 		});
+
+		it('should handle empty key', () => {
+			let cfg = new Config();
+			expect(cfg.has([])).to.equal(true);
+
+			cfg = new Config({
+				data: {
+					foo: {
+						pow: true
+					}
+				}
+			});
+			expect(cfg.has([])).to.equal(true);
+		});
 	});
 
 	describe('data()', () => {

--- a/test/test-layers.js
+++ b/test/test-layers.js
@@ -1,4 +1,4 @@
-import LayerList from '../dist/layer-list';
+import LayerList, { Base } from '../dist/layer-list';
 
 describe('LayerList', () => {
 	it('should remove a layer', () => {
@@ -50,13 +50,13 @@ describe('LayerList', () => {
 		for (const item of list) {
 			ids.push(item.id);
 		}
-		expect(ids).to.deep.equal([ 'a', 'b', 'c' ]);
+		expect(ids).to.deep.equal([ Base, 'a', 'b', 'c' ]);
 
 		ids = [];
 		for (const item of list.reverse) {
 			ids.push(item.id);
 		}
-		expect(ids).to.deep.equal([ 'c', 'b', 'a' ]);
+		expect(ids).to.deep.equal([ 'c', 'b', 'a', Base ]);
 	});
 
 	it('should error if validator is not a function', () => {
@@ -93,5 +93,18 @@ describe('LayerList', () => {
 		expect(() => {
 			list.unwatch('foo');
 		}).to.throw(TypeError, 'Expected handler to be a function');
+	});
+
+	it('should error adding a layer with invalid data', () => {
+		const list = new LayerList();
+		expect(() => {
+			list.add({ id: 'foo', data: 'bar' });
+		}).to.throw(TypeError, 'Expected layer data to be an object');
+	});
+
+	it('should render a layer to a string', () => {
+		const list = new LayerList();
+		const layer = list.add({ id: 'foo', data: { foo: 'bar' } });
+		expect(layer.toString()).to.equal('{"foo":"bar"}');
 	});
 });

--- a/test/test-namespace.js
+++ b/test/test-namespace.js
@@ -1,0 +1,181 @@
+import Config, { Joi } from '../dist/index';
+import path from 'path';
+
+describe('Namespaces', () => {
+	describe('schemaless', () => {
+		describe('layer', () => {
+			it('should create a new namespaced layer with data', () => {
+				const cfg = new Config();
+				cfg.layers.add({
+					data: { foo: 'bar' },
+					id: 'test',
+					namespace: 'test'
+				});
+				expect(cfg.get()).to.deep.equal({
+					test: {
+						foo: 'bar'
+					}
+				});
+			});
+		});
+
+		describe('load()', () => {
+			it('should load a file into a namespaced layer', () => {
+				const cfg = new Config();
+				cfg.load(path.join(__dirname, 'fixtures', 'json', 'good.json'), { namespace: 'test' });
+
+				expect(cfg.get()).to.deep.equal({ test: { foo: 'bar' } });
+				expect(cfg.get('foo')).to.equal(undefined);
+				expect(cfg.get('test')).to.deep.equal({ foo: 'bar' });
+				expect(cfg.get('test.foo')).to.equal('bar');
+			});
+		});
+
+		describe('get()', () => {
+			it('should get an empty layer', () => {
+				const cfg = new Config();
+				expect(cfg.get()).to.deep.equal({});
+
+				cfg.layers.add({
+					id: 'test',
+					namespace: 'test'
+				});
+
+				expect(cfg.get()).to.deep.equal({ test: {} });
+				expect(cfg.get('test')).to.deep.equal({});
+				expect(cfg.get('test.foo')).to.equal(undefined);
+			});
+		});
+
+		describe('has()', () => {
+			it('should return undefined for empty layer', () => {
+				const cfg = new Config();
+				cfg.layers.add({
+					id: 'test',
+					namespace: 'test'
+				});
+
+				expect(cfg.has()).to.equal(true);
+				expect(cfg.has('foo')).to.equal(false);
+				expect(cfg.has('test')).to.equal(true);
+				expect(cfg.has('test.foo')).to.equal(false);
+			});
+		});
+
+		describe('merge()', () => {
+			it('should merge data into namespaced layer', () => {
+				const cfg = new Config();
+				cfg.layers.add({
+					id: 'test',
+					namespace: 'test'
+				});
+
+				expect(cfg.get()).to.deep.equal({ test: {} });
+
+				cfg.merge({ foo: 'bar' });
+
+				expect(cfg.get()).to.deep.equal({
+					foo: 'bar',
+					test: {}
+				});
+
+				cfg.merge({ test: { baz: 'wiz' } });
+
+				expect(cfg.get()).to.deep.equal({
+					foo: 'bar',
+					test: {
+						baz: 'wiz'
+					}
+				});
+			});
+		});
+
+		describe('set()/delete()', () => {
+			it('should set a value in a namespaced layer', () => {
+				const cfg = new Config();
+				cfg.layers.add({
+					id: 'test',
+					namespace: 'test'
+				});
+
+				cfg.set('test.foo', 'bar', 'test');
+				expect(cfg.get()).to.deep.equal({ test: { foo: 'bar' } });
+
+				expect(cfg.data('test')).to.deep.equal({ foo: 'bar' });
+
+				cfg.delete('test.foo');
+				expect(cfg.data('test')).to.deep.equal({});
+				expect(cfg.get('test')).to.deep.equal({});
+				expect(cfg.get()).to.deep.equal({ test: {} });
+
+				cfg.delete('test');
+				expect(cfg.data('test')).to.deep.equal({});
+				expect(cfg.get('test')).to.deep.equal({});
+			});
+		});
+	});
+
+	describe('schema', () => {
+		describe('load()', () => {
+			it('should fail if loaded file validation fails', () => {
+				const cfg = new Config();
+				expect(() => {
+					cfg.load(path.join(__dirname, 'fixtures', 'json', 'good.json'), {
+						namespace: 'test',
+						schema: Joi.object({
+							foo: Joi.string().valid('baz'),
+							count: Joi.number().valid(1)
+						})
+					});
+				}).to.throw(Error, /^Failed to load config file/);
+			});
+		});
+
+		describe('merge()', () => {
+			it('should fail to merge if schema validation fails', () => {
+				const cfg = new Config();
+				cfg.layers.add({
+					id: 'test',
+					namespace: 'test',
+					schema: Joi.object({
+						foo: Joi.string().valid('bar'),
+						count: Joi.number().valid(0)
+					})
+				});
+
+				expect(cfg.get()).to.deep.equal({ test: {} });
+
+				cfg.merge({ test: { foo: 'bar' } });
+				expect(cfg.get()).to.deep.equal({ test: { foo: 'bar' } });
+
+				expect(() => {
+					cfg.merge({ test: { count: 'bar' } });
+				}).to.throw(Error, /^Failed to merge config value/);
+			});
+		});
+
+		describe('set()/delete()', () => {
+			it('should fail to delete a value', () => {
+				const cfg = new Config();
+				cfg.layers.add({
+					data: { foo: 'bar' },
+					id: 'test',
+					namespace: 'test',
+					schema: Joi.object({
+						foo: Joi.string().valid('bar').meta({ readonly: true })
+					})
+				});
+
+				expect(cfg.get()).to.deep.equal({ test: { foo: 'bar' } });
+
+				expect(() => {
+					cfg.set('test.foo', 'baz', 'test');
+				}).to.throw(Error, 'Not allowed to set read-only property');
+
+				expect(() => {
+					cfg.delete('test.foo');
+				}).to.throw(Error, 'Not allowed to delete read-only property');
+			});
+		});
+	});
+});

--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -100,6 +100,13 @@ describe('Schema', () => {
 			namespace: 'test',
 			schema: path.join(__dirname, 'fixtures', 'schema', 'good.json')
 		});
+
+		expect(cfg.get()).to.deep.equal({ test: { foo: 'bar' } });
+		cfg.merge({ baz: 'wiz' });
+		expect(cfg.get()).to.deep.equal({ test: { foo: 'bar' } });
+
+		cfg.merge({ test: { baz: 'wiz' } });
+		expect(cfg.get()).to.deep.equal({ test: { foo: 'bar', baz: 'wiz' } });
 	});
 
 	it('should error manually loading schema', () => {
@@ -201,7 +208,7 @@ describe('Schema', () => {
 		expect(cfg.get('b')).to.equal(12);
 		expect(() => {
 			cfg.set('b', 1);
-		}).to.throw(Error, 'Failed to set config value: "value" must be larger than or equal to 10');
+		}).to.throw(Error, 'Failed to set config value: "value" must be greater than or equal to 10');
 		expect(() => {
 			cfg.set('b', 21);
 		}).to.throw(Error, 'Failed to set config value: "value" must be less than or equal to 20');
@@ -252,7 +259,7 @@ describe('Schema', () => {
 				c: Joi.alternatives()
 					.try(
 						Joi.object({
-							d: Joi.object().meta({ readonly: true })
+							d: Joi.string().meta({ readonly: true })
 						}),
 						Joi.number()
 					),

--- a/yarn.lock
+++ b/yarn.lock
@@ -325,38 +325,10 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
-"@hapi/address@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-4.0.1.tgz#267301ddf7bc453718377a6fb3832a2f04a721dd"
-  integrity sha512-0oEP5UiyV4f3d6cBL8F3Z5S7iWSX39Knnl0lY8i+6gfmmIBj44JCBNtcMgwyS+5v7j3VYavNay0NFHDS+UGQcw==
-  dependencies:
-    "@hapi/hoek" "^9.0.0"
-
-"@hapi/formula@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/formula/-/formula-2.0.0.tgz#edade0619ed58c8e4f164f233cda70211e787128"
-  integrity sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==
-
 "@hapi/hoek@^9.0.0":
   version "9.0.4"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.0.4.tgz#e80ad4e8e8d2adc6c77d985f698447e8628b6010"
   integrity sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw==
-
-"@hapi/joi@^17.1.1":
-  version "17.1.1"
-  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-17.1.1.tgz#9cc8d7e2c2213d1e46708c6260184b447c661350"
-  integrity sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==
-  dependencies:
-    "@hapi/address" "^4.0.1"
-    "@hapi/formula" "^2.0.0"
-    "@hapi/hoek" "^9.0.0"
-    "@hapi/pinpoint" "^2.0.0"
-    "@hapi/topo" "^5.0.0"
-
-"@hapi/pinpoint@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/pinpoint/-/pinpoint-2.0.0.tgz#805b40d4dbec04fc116a73089494e00f073de8df"
-  integrity sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw==
 
 "@hapi/topo@^5.0.0":
   version "5.0.0"
@@ -380,6 +352,23 @@
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
+
+"@sideway/address@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.0.tgz#0b301ada10ac4e0e3fa525c90615e0b61a72b78d"
+  integrity sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.7.2":
   version "1.8.0"
@@ -4286,6 +4275,17 @@ iterate-value@^1.0.0:
   dependencies:
     es-get-iterator "^1.0.2"
     iterate-iterator "^1.0.1"
+
+joi@^17.3.0:
+  version "17.3.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.3.0.tgz#f1be4a6ce29bc1716665819ac361dfa139fff5d2"
+  integrity sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.0"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
* fix(Layer): Move layer namespace handling from store to layer.
* fix(Layer): Allow 'has()' to be passed an empty key.
* fix(Layer): Added schema validation when initializing a layer with data.
* fix(LayerList): Moved 'Base' layer definition from 'Config' into 'LayerList' because the layer schema validator needs the base layer's schema and we need to make sure the base layer exists and thus needs to own the 'Base' symbol.
* fix(LayerList): Validator should only use base layer's schema and current layer's schema to validate, not all layer's schemas.
* fix(LayerList): Fixed bug where layers were not being inserted into the layer list sequentially.
* fix(JSONStore): Fixed 'get()' and 'has()' to only iterate over the data object if the 'key' has a length.
* fix(util): In 'getSchemaInitialValues()', only return 'env' object if there were environment variable values found.
* refactor(Store): Changed 'Store.load()' to only take a 'file'. Not counting this as a breaking change as it's an internal API.
* build: Update Babel config from Node 8 to Node 10.
* test: Added several namespace related tests.
* test: Fixed several bad tests.
* chore: Migrated from '@hapi/joi' to 'joi'.